### PR TITLE
Fix Babel standalone scripts by using global namespace

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,13 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 
-  <!-- Start the app (Babel will transpile ES modules + JSX on the fly) -->
-  <script type="text/babel" data-presets="env,react" data-type="module" src="./js/app.jsx"></script>
+  <!-- Load game files (Babel transpiles each). No import/export in these files. -->
+  <script type="text/babel" data-presets="env"  src="./js/constants.js"></script>
+  <script type="text/babel" data-presets="env"  src="./js/utils.js"></script>
+  <script type="text/babel" data-presets="env"  src="./js/landuse.js"></script>
+  <script type="text/babel" data-presets="env"  src="./js/poi.js"></script>
+  <script type="text/babel" data-presets="env"  src="./js/sim.js"></script>
+  <script type="text/babel" data-presets="env,react" src="./js/ui.jsx"></script>
+  <script type="text/babel" data-presets="env,react" src="./js/app.jsx"></script>
 </body>
 </html>

--- a/js/app.jsx
+++ b/js/app.jsx
@@ -1,4 +1,5 @@
-import {
+const TS = window.TS || (window.TS = {});
+const {
   GRID, CELL_SIZE, CANVAS_SIZE,
   START_POP, POP_GROWTH_PER_YEAR, MODE_SHARE_TARGET, MODE_SHARE_STREAK_DAYS,
   DEFAULT_SERVICE_START_HOUR, DEFAULT_SERVICE_END_HOUR,
@@ -7,16 +8,16 @@ import {
   INITIAL_FLEET, DEPOT_BASE_CAPACITY, DEPOT_EXPANSION_STEP, DEPOT_EXPANSION_COST,
   BASE_MAINT_PER_BUS_YEAR, SHIFT_HOURS, OVERTIME_MULT,
   FUELS, SIM_MINUTES_PER_TICK, TICK_MS
-} from './constants.js';
+} = TS;
 
-import { clamp } from './utils.js';
-import { generateLandUse } from './landuse.js';
-import { generatePOIs, poiIcon, poiJobsBoost } from './poi.js';
-import {
+const { clamp, polylineLengthKm } = TS;
+const { generateLandUse } = TS;
+const { generatePOIs, poiIcon, poiJobsBoost } = TS;
+const {
   cycleTimeHours, actualVehPerHour, capacityPerHour, avgWaitMin,
   demandPerHour, priceFactor, waitFactor, effSpeedFromLoad, financesMinute
-} from './sim.js';
-import { useBanners } from './ui.jsx';
+} = TS;
+const { useBanners } = TS;
 
 const { useEffect, useMemo, useState, useRef } = React;
 
@@ -230,7 +231,7 @@ function App(){
             <div className="grid grid-cols-2 gap-3">
               <div className="rounded-xl bg-slate-50 border border-slate-200 p-3">
                 <div className="text-sm font-medium text-slate-900">Fleet & Depot</div>
-                <div className="text-xs text-slate-600 mt-1">Buses: <span className="font-semibold">{fleet}</span> | Depot cap: <span className="font-semibold">{depotCap}</span></div>
+                <div className="text-xs text-slate-600 mt-1">Buses: <span className="font-semibold">{fleet}</span> | Depot cap:<span className="font-semibold">{depotCap}</span></div>
                 <div className="text-xs text-slate-600">Max throughput: <span className="font-semibold">{Math.floor(maxThrough)}</span> veh/hr</div>
                 <div className="mt-2 flex gap-2 flex-wrap">
                   <button onClick={()=> buyBuses(1)}  className="px-2 py-1 rounded-lg text-xs bg-white border border-slate-300 hover:bg-slate-100">Buy 1 ({FUELS[fuel].busCost.toLocaleString()})</button>

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,72 +1,52 @@
-// City & grid
-export const GRID = 20;
-export const CELL_SIZE = 24;
-export const CANVAS_SIZE = GRID * CELL_SIZE;
-
-export const START_POP = 100_000;
-export const POP_GROWTH_PER_YEAR = 5_000;
-export const MODE_SHARE_TARGET = 5;       // %
-export const MODE_SHARE_STREAK_DAYS = 30; // days
-
-// Service
-export const DEFAULT_SERVICE_START_HOUR = 6;
-export const DEFAULT_SERVICE_END_HOUR   = 22;
-
-// Economics
-export const STARTING_CASH = 5_000_000;
-export const STOP_CAPEX = 15_000;
-export const DRIVER_WAGE_PER_HOUR = 60;
-export const OVERHEAD_PER_VEH_HOUR = 60;
-
-// Vehicles
-export const VEHICLE_SPEED_BASE = 25; // km/h
-export const SEATED_CAP = 40, STANDING_CAP = 25, CRUSH_EXTRA = 10;
-export const VEHICLE_CAPACITY = SEATED_CAP + STANDING_CAP + CRUSH_EXTRA; // 75
-export const INITIAL_FLEET = 10;
-
-export const DEPOT_BASE_CAPACITY = 25;
-export const DEPOT_EXPANSION_STEP = 50;
-export const DEPOT_EXPANSION_COST = 8_000_000;
-export const TURNAROUND_MIN = 6;
-
-// Fuels
-export const FUELS = {
-  Diesel: { busCost: 550_000, costPerKm: 1.10, emissions: 1.0 },
-  CNG:    { busCost: 600_000, costPerKm: 0.90, emissions: 0.7 },
-  BEV:    { busCost: 900_000, costPerKm: 0.50, emissions: 0.2 },
-};
-
-// Maintenance
-export const BASE_MAINT_PER_BUS_YEAR = 35_000;
-
-// Drivers
-export const INITIAL_DRIVERS = 20;
-export const SHIFT_HOURS = 8;
-export const OVERTIME_MULT = 1.5;
-
-// Demand
-export const BASE_DEMAND_PER_CELL_PER_HOUR = 11.5;
-export const JOB_ATTRACTION_PER_CELL = 10;
-export const COVERAGE_RADIUS = 3;
-export const WALK_DECAY = 0.35;
-export const TARGET_STOP_SPACING_CELLS = 3;
-export const FARE_REF = 2.0;
-export const FARE_ELASTICITY = -0.25;
-export const WAIT_TIME_SENSITIVITY = 0.06;
-
-// Subsidy
-export const SUBSIDY_PER_BOARDING = 1.00;
-export const RESIDUAL_GAP_SHARE = 0.2;
-
-// Time
-export const SIM_MINUTES_PER_TICK = 1;
-export const TICK_MS = 600;
-
-// POIs
-export const AIRPORT_POP_THRESHOLD = 150_000;
-export const POI_TYPES = [
-  { key:'retail',  label:'Retail',  icon:'🛍️', jobsBoost: 1.0 },
-  { key:'school',  label:'School',  icon:'🏫', jobsBoost: 0.8 },
-  { key:'tourism', label:'Tourism', icon:'🎡', jobsBoost: 1.2 },
-  { key:'airport', label:'Airport', icon:'✈️', jobsBoost: 2.0 },
-];
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  TS.GRID = 20;
+  TS.CELL_SIZE = 24;
+  TS.CANVAS_SIZE = TS.GRID * TS.CELL_SIZE;
+  TS.START_POP = 100_000;
+  TS.POP_GROWTH_PER_YEAR = 5_000;
+  TS.MODE_SHARE_TARGET = 5;
+  TS.MODE_SHARE_STREAK_DAYS = 30;
+  TS.DEFAULT_SERVICE_START_HOUR = 6;
+  TS.DEFAULT_SERVICE_END_HOUR = 22;
+  TS.STARTING_CASH = 5_000_000;
+  TS.STOP_CAPEX = 15_000;
+  TS.DRIVER_WAGE_PER_HOUR = 60;
+  TS.OVERHEAD_PER_VEH_HOUR = 60;
+  TS.VEHICLE_SPEED_BASE = 25;
+  TS.SEATED_CAP = 40; TS.STANDING_CAP = 25; TS.CRUSH_EXTRA = 10;
+  TS.VEHICLE_CAPACITY = TS.SEATED_CAP + TS.STANDING_CAP + TS.CRUSH_EXTRA;
+  TS.INITIAL_FLEET = 10;
+  TS.DEPOT_BASE_CAPACITY = 25;
+  TS.DEPOT_EXPANSION_STEP = 50;
+  TS.DEPOT_EXPANSION_COST = 8_000_000;
+  TS.TURNAROUND_MIN = 6;
+  TS.FUELS = {
+    Diesel: { busCost: 550_000, costPerKm: 1.10, emissions: 1.0 },
+    CNG:    { busCost: 600_000, costPerKm: 0.90, emissions: 0.7 },
+    BEV:    { busCost: 900_000, costPerKm: 0.50, emissions: 0.2 },
+  };
+  TS.BASE_MAINT_PER_BUS_YEAR = 35_000;
+  TS.INITIAL_DRIVERS = 20;
+  TS.SHIFT_HOURS = 8;
+  TS.OVERTIME_MULT = 1.5;
+  TS.BASE_DEMAND_PER_CELL_PER_HOUR = 11.5;
+  TS.JOB_ATTRACTION_PER_CELL = 10;
+  TS.COVERAGE_RADIUS = 3;
+  TS.WALK_DECAY = 0.35;
+  TS.TARGET_STOP_SPACING_CELLS = 3;
+  TS.FARE_REF = 2.0;
+  TS.FARE_ELASTICITY = -0.25;
+  TS.WAIT_TIME_SENSITIVITY = 0.06;
+  TS.SUBSIDY_PER_BOARDING = 1.00;
+  TS.RESIDUAL_GAP_SHARE = 0.2;
+  TS.SIM_MINUTES_PER_TICK = 1;
+  TS.TICK_MS = 600;
+  TS.AIRPORT_POP_THRESHOLD = 150_000;
+  TS.POI_TYPES = [
+    { key:'retail',  label:'Retail',  icon:'🛍️', jobsBoost: 1.0 },
+    { key:'school',  label:'School',  icon:'🏫', jobsBoost: 0.8 },
+    { key:'tourism', label:'Tourism', icon:'🎡', jobsBoost: 1.2 },
+    { key:'airport', label:'Airport', icon:'✈️', jobsBoost: 2.0 },
+  ];
+})(window);

--- a/js/landuse.js
+++ b/js/landuse.js
@@ -1,18 +1,20 @@
-import { GRID } from './constants.js';
-import { mulberry32 } from './utils.js';
-
-export function generateLandUse(seed){
-  const rngPop = mulberry32(seed*101), rngJobs = mulberry32(seed*701);
-  const pop = Array.from({length:GRID}, ()=> Array(GRID).fill(0));
-  const jobs= Array.from({length:GRID}, ()=> Array(GRID).fill(0));
-  for(let y=0;y<GRID;y++) for(let x=0;x<GRID;x++){
-    const a=rngPop(), b=rngPop();
-    const cx=(x-GRID/2)/(GRID/2), cy=(y-GRID/2)/(GRID/2);
-    const centerBias=Math.exp(-(cx*cx+cy*cy)*1.2);
-    pop[y][x] = Math.floor(Math.min(3.2, (a*0.6+b*0.4)*0.5 + 0.5*centerBias) * 3.2);
-    const aj=rngJobs(), bj=rngJobs();
-    const ringBias = Math.exp(-Math.pow(((cx*cx+cy*cy)-0.25),2) * 2);
-    jobs[y][x]= Math.floor(Math.min(3.2, (aj*0.5+bj*0.5)*0.5 + 0.5*ringBias) * 3.2);
-  }
-  return { pop, jobs };
-}
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  const { GRID } = TS;
+  const { mulberry32 } = TS;
+  TS.generateLandUse = function (seed) {
+    const rngPop = mulberry32(seed * 101), rngJobs = mulberry32(seed * 701);
+    const pop = Array.from({ length: GRID }, () => Array(GRID).fill(0));
+    const jobs = Array.from({ length: GRID }, () => Array(GRID).fill(0));
+    for (let y = 0; y < GRID; y++) for (let x = 0; x < GRID; x++) {
+      const a = rngPop(), b = rngPop();
+      const cx = (x - GRID / 2) / (GRID / 2), cy = (y - GRID / 2) / (GRID / 2);
+      const centerBias = Math.exp(-(cx * cx + cy * cy) * 1.2);
+      pop[y][x] = Math.floor(Math.min(3.2, (a * 0.6 + b * 0.4) * 0.5 + 0.5 * centerBias) * 3.2);
+      const aj = rngJobs(), bj = rngJobs();
+      const ringBias = Math.exp(-Math.pow(((cx * cx + cy * cy) - 0.25), 2) * 2);
+      jobs[y][x] = Math.floor(Math.min(3.2, (aj * 0.5 + bj * 0.5) * 0.5 + 0.5 * ringBias) * 3.2);
+    }
+    return { pop, jobs };
+  };
+})(window);

--- a/js/poi.js
+++ b/js/poi.js
@@ -1,41 +1,41 @@
-import { GRID, AIRPORT_POP_THRESHOLD, POI_TYPES } from './constants.js';
-import { clamp, mulberry32 } from './utils.js';
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  const { GRID, AIRPORT_POP_THRESHOLD, POI_TYPES } = TS;
+  const { clamp, mulberry32 } = TS;
+  const iconFor = key => POI_TYPES.find(p => p.key === key)?.icon || '';
+  const boostFor = key => POI_TYPES.find(p => p.key === key)?.jobsBoost || 0;
+  TS.poiIcon = function (key) { return iconFor(key); };
+  TS.poiJobsBoost = function (key) { return boostFor(key); };
+  TS.generatePOIs = function (seed, population) {
+    const rng = mulberry32(seed * 999);
+    const count = Math.round(GRID * GRID * 0.08);
+    const poiMap = new Map();
+    const downtown = { x: Math.floor(GRID / 2), y: Math.floor(GRID / 2) };
+    const sat1 = { x: Math.floor(GRID * 0.25), y: Math.floor(GRID * 0.3) };
+    const sat2 = { x: Math.floor(GRID * 0.75), y: Math.floor(GRID * 0.7) };
 
-const iconFor = key => POI_TYPES.find(p=>p.key===key)?.icon || '';
-const boostFor = key => POI_TYPES.find(p=>p.key===key)?.jobsBoost || 0;
-
-export function poiIcon(key){ return iconFor(key); }
-export function poiJobsBoost(key){ return boostFor(key); }
-
-export function generatePOIs(seed, population){
-  const rng = mulberry32(seed*999);
-  const count = Math.round(GRID*GRID*0.08);
-  const poiMap = new Map();
-  const downtown = { x: Math.floor(GRID/2), y: Math.floor(GRID/2) };
-  const sat1 = { x: Math.floor(GRID*0.25), y: Math.floor(GRID*0.3) };
-  const sat2 = { x: Math.floor(GRID*0.75), y: Math.floor(GRID*0.7) };
-
-  function pick(){ const r=rng(); if(r<0.45) return 'retail'; if(r<0.65) return 'school'; if(r<0.90) return 'tourism'; return 'retail'; }
-  function placeNear(center, share){
-    const n = Math.round(count*share);
-    for(let i=0;i<n;i++){
-      const dx = Math.round((rng()-0.5)*6), dy = Math.round((rng()-0.5)*6);
-      const x = clamp(center.x+dx, 0, GRID-1), y = clamp(center.y+dy, 0, GRID-1);
-      const key = `${x},${y}`; if(!poiMap.has(key)) poiMap.set(key, pick());
+    function pick() { const r = rng(); if (r < 0.45) return 'retail'; if (r < 0.65) return 'school'; if (r < 0.90) return 'tourism'; return 'retail'; }
+    function placeNear(center, share) {
+      const n = Math.round(count * share);
+      for (let i = 0; i < n; i++) {
+        const dx = Math.round((rng() - 0.5) * 6), dy = Math.round((rng() - 0.5) * 6);
+        const x = clamp(center.x + dx, 0, GRID - 1), y = clamp(center.y + dy, 0, GRID - 1);
+        const key = `${x},${y}`; if (!poiMap.has(key)) poiMap.set(key, pick());
+      }
     }
-  }
-  function placeRandom(share){
-    const n = Math.round(count*share);
-    for(let i=0;i<n;i++){
-      const x = Math.floor(rng()*GRID), y = Math.floor(rng()*GRID);
-      const key = `${x},${y}`; if(!poiMap.has(key)) poiMap.set(key, pick());
+    function placeRandom(share) {
+      const n = Math.round(count * share);
+      for (let i = 0; i < n; i++) {
+        const x = Math.floor(rng() * GRID), y = Math.floor(rng() * GRID);
+        const key = `${x},${y}`; if (!poiMap.has(key)) poiMap.set(key, pick());
+      }
     }
-  }
 
-  placeNear(downtown, 0.6); placeNear(sat1, 0.1); placeNear(sat2, 0.1); placeRandom(0.2);
-  if(population >= AIRPORT_POP_THRESHOLD){
-    const edge = rng() < 0.5 ? { x: GRID-2, y: Math.floor(GRID*0.2) } : { x: 1, y: Math.floor(GRID*0.8) };
-    poiMap.set(`${edge.x},${edge.y}`, 'airport');
-  }
-  return poiMap;
-}
+    placeNear(downtown, 0.6); placeNear(sat1, 0.1); placeNear(sat2, 0.1); placeRandom(0.2);
+    if (population >= AIRPORT_POP_THRESHOLD) {
+      const edge = rng() < 0.5 ? { x: GRID - 2, y: Math.floor(GRID * 0.2) } : { x: 1, y: Math.floor(GRID * 0.8) };
+      poiMap.set(`${edge.x},${edge.y}`, 'airport');
+    }
+    return poiMap;
+  };
+})(window);

--- a/js/sim.js
+++ b/js/sim.js
@@ -1,70 +1,72 @@
-import {
-  VEHICLE_CAPACITY, VEHICLE_SPEED_BASE, TURNAROUND_MIN,
-  BASE_DEMAND_PER_CELL_PER_HOUR, JOB_ATTRACTION_PER_CELL,
-  WALK_DECAY, FARE_REF, FARE_ELASTICITY, WAIT_TIME_SENSITIVITY,
-  SUBSIDY_PER_BOARDING, RESIDUAL_GAP_SHARE, START_POP
-} from './constants.js';
-import { polylineLengthKm } from './utils.js';
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  const {
+    VEHICLE_CAPACITY, VEHICLE_SPEED_BASE, TURNAROUND_MIN,
+    BASE_DEMAND_PER_CELL_PER_HOUR, JOB_ATTRACTION_PER_CELL,
+    WALK_DECAY, FARE_REF, FARE_ELASTICITY, WAIT_TIME_SENSITIVITY,
+    SUBSIDY_PER_BOARDING, RESIDUAL_GAP_SHARE, START_POP
+  } = TS;
+  const { polylineLengthKm } = TS;
 
-export function cycleTimeHours(stops, effSpeed){
-  const km = polylineLengthKm(stops);
-  const run = km / Math.max(5, effSpeed);
-  return Math.max(0.05, run*2 + TURNAROUND_MIN/60);
-}
-export function actualVehPerHour(target, fleetCap){
-  return Math.min(target, Math.floor(fleetCap));
-}
-export function capacityPerHour(veh){ return veh * VEHICLE_CAPACITY; }
-export function avgWaitMin(veh){ return veh>0 ? (60/veh)/2 : Infinity; }
+  TS.cycleTimeHours = function (stops, effSpeed) {
+    const km = polylineLengthKm(stops);
+    const run = km / Math.max(5, effSpeed);
+    return Math.max(0.05, run * 2 + TURNAROUND_MIN / 60);
+  };
+  TS.actualVehPerHour = function (target, fleetCap) {
+    return Math.min(target, Math.floor(fleetCap));
+  };
+  TS.capacityPerHour = function (veh) { return veh * VEHICLE_CAPACITY; };
+  TS.avgWaitMin = function (veh) { return veh > 0 ? (60 / veh) / 2 : Infinity; };
 
-export function spacingEfficiency(stops, targetSpacing=3){
-  if(stops.length<2) return 0.6;
-  let sum=0,n=0; for(let i=1;i<stops.length;i++){
-    sum += Math.abs(stops[i-1].x-stops[i].x)+Math.abs(stops[i-1].y-stops[i].y); n++;
-  }
-  const avg=sum/n; const ratio = Math.min(avg, targetSpacing)/Math.max(avg, targetSpacing);
-  return 0.6 + 0.4*ratio;
-}
-
-export function demandPerHour({ stops, land, population, poiMap }){
-  if(stops.length===0) return 0;
-  const dist = new Map(); const R=3;
-  for(const s of stops){
-    for(let dy=-R;dy<=R;dy++) for(let dx=-R;dx<=R;dx++){
-      const nx=s.x+dx, ny=s.y+dy;
-      if(nx<0||ny<0||nx>=land.pop[0].length||ny>=land.pop.length) continue;
-      const d=Math.abs(dx)+Math.abs(dy); if(d>R) continue;
-      const k=`${nx},${ny}`; dist.set(k, Math.min(d, dist.get(k) ?? d));
+  TS.spacingEfficiency = function (stops, targetSpacing = 3) {
+    if (stops.length < 2) return 0.6;
+    let sum = 0, n = 0; for (let i = 1; i < stops.length; i++) {
+      sum += Math.abs(stops[i - 1].x - stops[i].x) + Math.abs(stops[i - 1].y - stops[i].y); n++;
     }
-  }
-  let popSum=0, jobsSum=0, poiBoost=0;
-  dist.forEach((d,k)=>{
-    const [x,y]=k.split(',').map(Number);
-    const w=Math.exp(-WALK_DECAY*d);
-    popSum += land.pop[y][x]*w;
-    jobsSum+= land.jobs[y][x]*w;
-    const poi = poiMap.get(k); if(poi) poiBoost += poi === 'airport' ? 2*w : w;
-  });
+    const avg = sum / n; const ratio = Math.min(avg, targetSpacing) / Math.max(avg, targetSpacing);
+    return 0.6 + 0.4 * ratio;
+  };
 
-  const popScale = population/START_POP;
-  const jobsEff = (jobsSum * JOB_ATTRACTION_PER_CELL) + (poiBoost*5);
-  const spacing = spacingEfficiency(stops);
-  return (popSum * BASE_DEMAND_PER_CELL_PER_HOUR) * Math.pow(jobsEff, 0.5) * spacing * popScale;
-}
+  TS.demandPerHour = function ({ stops, land, population, poiMap }) {
+    if (stops.length === 0) return 0;
+    const dist = new Map(); const R = 3;
+    for (const s of stops) {
+      for (let dy = -R; dy <= R; dy++) for (let dx = -R; dx <= R; dx++) {
+        const nx = s.x + dx, ny = s.y + dy;
+        if (nx < 0 || ny < 0 || nx >= land.pop[0].length || ny >= land.pop.length) continue;
+        const d = Math.abs(dx) + Math.abs(dy); if (d > R) continue;
+        const k = `${nx},${ny}`; dist.set(k, Math.min(d, dist.get(k) ?? d));
+      }
+    }
+    let popSum = 0, jobsSum = 0, poiBoost = 0;
+    dist.forEach((d, k) => {
+      const [x, y] = k.split(',').map(Number);
+      const w = Math.exp(-WALK_DECAY * d);
+      popSum += land.pop[y][x] * w;
+      jobsSum += land.jobs[y][x] * w;
+      const poi = poiMap.get(k); if (poi) poiBoost += poi === 'airport' ? 2 * w : w;
+    });
 
-export function priceFactor(fare){ return Math.pow(Math.max(0.5, Math.min(5,fare))/FARE_REF, FARE_ELASTICITY); }
-export function waitFactor(avgWait){ return Math.exp(-WAIT_TIME_SENSITIVITY * (isFinite(avgWait)? avgWait : 60)); }
-export function effSpeedFromLoad(load){ return VEHICLE_SPEED_BASE * (1 - 0.25 * Math.max(0, load-0.8)); }
+    const popScale = population / START_POP;
+    const jobsEff = (jobsSum * JOB_ATTRACTION_PER_CELL) + (poiBoost * 5);
+    const spacing = TS.spacingEfficiency(stops);
+    return (popSum * BASE_DEMAND_PER_CELL_PER_HOUR) * Math.pow(jobsEff, 0.5) * spacing * popScale;
+  };
 
-export function financesMinute({ withinService, servedPerHour, fare,
-  actualVehPerHour, wageRate, overheadPerVehHour, speedKmH, costPerKm,
-  hourlyMaint, staffingPerMinute })
-{
-  const revenuePerMinute = withinService ? (servedPerHour * fare) / 60 : 0;
-  const opCostPerHour = (withinService ? (actualVehPerHour * (wageRate + overheadPerVehHour) + actualVehPerHour * (speedKmH * costPerKm)) : 0) + hourlyMaint;
-  const opCostPerMinute = opCostPerHour/60 + staffingPerMinute;
-  const subsidyBoardingPerMinute = withinService ? (servedPerHour * SUBSIDY_PER_BOARDING) / 60 : 0;
-  const gapPerMinute = Math.max(0, opCostPerMinute - revenuePerMinute - subsidyBoardingPerMinute);
-  const subsidyResidualPerMinute = gapPerMinute * RESIDUAL_GAP_SHARE;
-  return revenuePerMinute - opCostPerMinute + subsidyBoardingPerMinute + subsidyResidualPerMinute;
-}
+  TS.priceFactor = function (fare) { return Math.pow(Math.max(0.5, Math.min(5, fare)) / FARE_REF, FARE_ELASTICITY); };
+  TS.waitFactor = function (avgWait) { return Math.exp(-WAIT_TIME_SENSITIVITY * (isFinite(avgWait) ? avgWait : 60)); };
+  TS.effSpeedFromLoad = function (load) { return VEHICLE_SPEED_BASE * (1 - 0.25 * Math.max(0, load - 0.8)); };
+
+  TS.financesMinute = function ({ withinService, servedPerHour, fare,
+    actualVehPerHour, wageRate, overheadPerVehHour, speedKmH, costPerKm,
+    hourlyMaint, staffingPerMinute }) {
+    const revenuePerMinute = withinService ? (servedPerHour * fare) / 60 : 0;
+    const opCostPerHour = (withinService ? (actualVehPerHour * (wageRate + overheadPerVehHour) + actualVehPerHour * (speedKmH * costPerKm)) : 0) + hourlyMaint;
+    const opCostPerMinute = opCostPerHour / 60 + staffingPerMinute;
+    const subsidyBoardingPerMinute = withinService ? (servedPerHour * SUBSIDY_PER_BOARDING) / 60 : 0;
+    const gapPerMinute = Math.max(0, opCostPerMinute - revenuePerMinute - subsidyBoardingPerMinute);
+    const subsidyResidualPerMinute = gapPerMinute * RESIDUAL_GAP_SHARE;
+    return revenuePerMinute - opCostPerMinute + subsidyBoardingPerMinute + subsidyResidualPerMinute;
+  };
+})(window);

--- a/js/ui.jsx
+++ b/js/ui.jsx
@@ -1,28 +1,31 @@
-import React from "react";
-
-export function useBanners(){
-  const [queue, setQueue] = React.useState([]);
-  React.useEffect(()=>{ if(!queue.length) return;
-    const t=setTimeout(()=> setQueue([]), 10000); return ()=> clearTimeout(t);
-  }, [queue]);
-  const show = b => setQueue([b]);
-  const dismiss = ()=> setQueue([]);
-  const view = (
-    <div className="fixed top-4 right-4 z-50 space-y-2">
-      {queue.map((b,i)=>
-        <div key={i} className={`w-80 rounded-xl border p-3 shadow-sm animate-[fadein_150ms_ease-out] ${
-          b.type==='celebrate'?'bg-violet-50 border-violet-300 text-violet-900'
-          : b.type==='success' ? 'bg-emerald-50 border-emerald-300 text-emerald-900'
-          : b.type==='warn'    ? 'bg-amber-50 border-amber-300 text-amber-900'
-                               : 'bg-sky-50 border-sky-300 text-sky-900'
-        }`}>
-          <div className="flex items-start gap-2">
-            <div className="text-sm leading-snug flex-1">{b.text}</div>
-            <button onClick={dismiss} className="text-xs px-2 py-0.5 rounded border border-slate-300/70 hover:bg-white/40">✕</button>
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  const { useState, useEffect } = React;
+  TS.useBanners = function () {
+    const [queue, setQueue] = useState([]);
+    useEffect(() => {
+      if (!queue.length) return;
+      const t = setTimeout(() => setQueue([]), 10000); return () => clearTimeout(t);
+    }, [queue]);
+    const show = b => setQueue([b]);
+    const dismiss = () => setQueue([]);
+    const view = (
+      <div className="fixed top-4 right-4 z-50 space-y-2">
+        {queue.map((b, i) =>
+          <div key={i} className={`w-80 rounded-xl border p-3 shadow-sm animate-[fadein_150ms_ease-out] ${
+            b.type === 'celebrate' ? 'bg-violet-50 border-violet-300 text-violet-900'
+              : b.type === 'success' ? 'bg-emerald-50 border-emerald-300 text-emerald-900'
+                : b.type === 'warn' ? 'bg-amber-50 border-amber-300 text-amber-900'
+                  : 'bg-sky-50 border-sky-300 text-sky-900'
+          }`}>
+            <div className="flex items-start gap-2">
+              <div className="text-sm leading-snug flex-1">{b.text}</div>
+              <button onClick={dismiss} className="text-xs px-2 py-0.5 rounded border border-slate-300/70 hover:bg-white/40">✕</button>
+            </div>
           </div>
-        </div>
-      )}
-    </div>
-  );
-  return { show, view };
-}
+        )}
+      </div>
+    );
+    return { show, view };
+  };
+})(window);

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,19 @@
-export const clamp = (v,min,max)=> Math.max(min, Math.min(max, v));
-export const distance = (a,b)=> Math.hypot(a.x-b.x, a.y-b.y);
-export function mulberry32(a){ return function(){ let t=(a+=0x6D2B79F5); t=Math.imul(t^(t>>>15), t|1); t^= t + Math.imul(t^(t>>>7), t|61); return ((t^(t>>>14))>>>0)/4294967296; }; }
-export function polylineLengthKm(points){ if(points.length<2) return 0; let s=0; for(let i=1;i<points.length;i++) s+=distance(points[i-1],points[i]); return s*0.1; }
+(function (g) {
+  const TS = g.TS = g.TS || {};
+  TS.clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+  TS.distance = (a, b) => Math.hypot(a.x - b.x, a.y - b.y);
+  TS.mulberry32 = function (a) {
+    return function () {
+      let t = (a += 0x6D2B79F5);
+      t = Math.imul(t ^ (t >>> 15), t | 1);
+      t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  };
+  TS.polylineLengthKm = function (points) {
+    if (points.length < 2) return 0;
+    let s = 0;
+    for (let i = 1; i < points.length; i++) s += TS.distance(points[i - 1], points[i]);
+    return s * 0.1;
+  };
+})(window);


### PR DESCRIPTION
## Summary
- load the simulator scripts individually in index.html so Babel transpiles each file
- refactor all js/jsx files to attach their exports to a shared window.TS namespace and consume it from app.jsx

## Testing
- manual Playwright smoke test to confirm stops can be added and the sim auto-starts

------
https://chatgpt.com/codex/tasks/task_e_68e1c430d6bc832291f4e39d0efe6376