### PR TITLE
Ensure tutorial auto-start triggers only once

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -32,6 +32,7 @@ function App(){
   // Route & time
   const [stops,setStops]=useState([]);
   const [running,setRunning]=useState(false);
+  const [autoStarted,setAutoStarted]=useState(false);
   const [dayMinutes,setDayMinutes]=useState(0);
   const [totalMinutes,setTotalMinutes]=useState(0);
   const [serviceStartHour,setServiceStartHour]=useState(DEFAULT_SERVICE_START_HOUR);
@@ -86,7 +87,13 @@ function App(){
   function hireDrivers(n){ if(running) return; setDrivers(d=> Math.max(0,d+n)); }
 
   // Auto-start when a route exists (≥3 stops)
-  useEffect(()=>{ if(!running && stops.length>=3){ setRunning(true); banners.show({ type:'success', text:'🚌 Service started — simulation running.'}); } }, [stops.length, running]);
+  useEffect(()=>{
+    if(!autoStarted && stops.length>=3){
+      setAutoStarted(true);
+      setRunning(true);
+      banners.show({ type:'success', text:'🚌 Service started — simulation running.'});
+    }
+  }, [stops.length, autoStarted]);
 
   // Tick
   useEffect(()=>{
@@ -266,15 +273,16 @@ function App(){
             </div>
 
             <div className="flex gap-2 flex-wrap mt-1">
-              <button onClick={()=> setRunning(r=>!r)} className={`px-3 py-2 rounded-xl text-sm font-medium border ${running? 'bg-sky-100 border-sky-300':'bg-sky-500 text-white border-sky-600 hover:bg-sky-600'}`}>{running? 'Pause':'Play'}</button>
+              <button onClick={()=>{ if(!running) setAutoStarted(true); setRunning(r=>!r); }} className={`px-3 py-2 rounded-xl text-sm font-medium border ${running? 'bg-sky-100 border-sky-300':'bg-sky-500 text-white border-sky-600 hover:bg-sky-600'}`}>{running? 'Pause':'Play'}</button>
               <button onClick={()=>{
+                setRunning(false); setAutoStarted(false);
                 setStops([]); setCash(STARTING_CASH); setFleet(INITIAL_FLEET); setDepotCap(DEPOT_BASE_CAPACITY);
                 setAvgBusAge(3); setDrivers(20); setDayMinutes(0); setTotalMinutes(0); setDayVehHours(0); setEffSpeed(VEHICLE_SPEED_BASE);
                 setPopulation(START_POP); setModeShare(0); setStreakDays(0); setGraduated(false);
                 setServiceStartHour(DEFAULT_SERVICE_START_HOUR); setServiceEndHour(DEFAULT_SERVICE_END_HOUR);
                 setPoiMap(generatePOIs(seed, START_POP));
               }} className="px-3 py-2 rounded-xl text-sm font-medium border bg-white border-slate-300 hover:bg-slate-100">Reset</button>
-              <button onClick={()=> setSeed(s=> s+1)} className="px-3 py-2 rounded-xl text-sm font-medium border bg-white border-slate-300 hover:bg-slate-100">New Map</button>
+              <button onClick={()=>{ setRunning(false); setAutoStarted(false); setSeed(s=> s+1); }} className="px-3 py-2 rounded-xl text-sm font-medium border bg-white border-slate-300 hover:bg-slate-100">New Map</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add state to track whether the tutorial auto-start has already fired
- prevent the auto-start effect from re-triggering after manual play and reset the flag on full resets

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1c86d42288322a8b3437a90fee8dc