### PR TITLE
Remove numeric separators from constants

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -203,7 +203,7 @@ function App(){
       }
       return next;
     });
-    const years = Math.floor(nextTotalMinutes/525_600);
+    const years = Math.floor(nextTotalMinutes/525600);
     setPopulation(START_POP + years*POP_GROWTH_PER_YEAR);
   }, [serviceHoursToday, population, graduated, banners]);
 
@@ -302,7 +302,7 @@ function App(){
   // Milestones / advisories
   const lastMilestoneRef = useRef(0);
   useEffect(()=>{ [1,2,3,5].forEach(m=>{ if(modeShare>=m && lastMilestoneRef.current<m){ lastMilestoneRef.current=m; banners.show({ type:m===5?'celebrate':'success', text:`Ridership milestone: ${m}%`} ); } }); }, [modeShare]);
-  useEffect(()=>{ if(cash < 250_000) banners.show({ type:'warn', text:'Agency funds are low.'}); }, [cash]);
+  useEffect(()=>{ if(cash < 250000) banners.show({ type:'warn', text:'Agency funds are low.'}); }, [cash]);
   useEffect(()=>{ if(loadFactor>0.9) banners.show({ type:'info', text:'Buses are overcrowded — add service.'}); }, [loadFactor]);
 
   // UI helpers

--- a/js/constants.js
+++ b/js/constants.js
@@ -3,14 +3,14 @@
   TS.GRID = 20;
   TS.CELL_SIZE = 24;
   TS.CANVAS_SIZE = TS.GRID * TS.CELL_SIZE;
-  TS.START_POP = 100_000;
-  TS.POP_GROWTH_PER_YEAR = 5_000;
+  TS.START_POP = 100000;
+  TS.POP_GROWTH_PER_YEAR = 5000;
   TS.MODE_SHARE_TARGET = 5;
   TS.MODE_SHARE_STREAK_DAYS = 30;
   TS.DEFAULT_SERVICE_START_HOUR = 6;
   TS.DEFAULT_SERVICE_END_HOUR = 22;
-  TS.STARTING_CASH = 5_000_000;
-  TS.STOP_CAPEX = 15_000;
+  TS.STARTING_CASH = 5000000;
+  TS.STOP_CAPEX = 15000;
   TS.DRIVER_WAGE_PER_HOUR = 60;
   TS.OVERHEAD_PER_VEH_HOUR = 60;
   TS.VEHICLE_SPEED_BASE = 25;
@@ -19,14 +19,14 @@
   TS.INITIAL_FLEET = 10;
   TS.DEPOT_BASE_CAPACITY = 25;
   TS.DEPOT_EXPANSION_STEP = 50;
-  TS.DEPOT_EXPANSION_COST = 8_000_000;
+  TS.DEPOT_EXPANSION_COST = 8000000;
   TS.TURNAROUND_MIN = 6;
   TS.FUELS = {
-    Diesel: { busCost: 550_000, costPerKm: 1.10, emissions: 1.0 },
-    CNG:    { busCost: 600_000, costPerKm: 0.90, emissions: 0.7 },
-    BEV:    { busCost: 900_000, costPerKm: 0.50, emissions: 0.2 },
+    Diesel: { busCost: 550000, costPerKm: 1.10, emissions: 1.0 },
+    CNG:    { busCost: 600000, costPerKm: 0.90, emissions: 0.7 },
+    BEV:    { busCost: 900000, costPerKm: 0.50, emissions: 0.2 },
   };
-  TS.BASE_MAINT_PER_BUS_YEAR = 35_000;
+  TS.BASE_MAINT_PER_BUS_YEAR = 35000;
   TS.INITIAL_DRIVERS = 20;
   TS.SHIFT_HOURS = 8;
   TS.OVERTIME_MULT = 1.5;
@@ -42,13 +42,13 @@
   TS.RESIDUAL_GAP_SHARE = 0.2;
   TS.SIM_MINUTES_PER_TICK = 1;
   TS.TICK_MS = 600;
-  TS.AIRPORT_POP_THRESHOLD = 150_000;
+  TS.AIRPORT_POP_THRESHOLD = 150000;
   TS.POI_TYPES = [
     { key:'retail',     label:'Retail',     icon:'🛍️', jobsBoost: 1.0 },
     { key:'school',     label:'School',     icon:'🏫', jobsBoost: 0.8 },
     { key:'tourism',    label:'Tourism',    icon:'🎡', jobsBoost: 1.2 },
-    { key:'healthcare', label:'Healthcare', icon:'🏥', jobsBoost: 1.3, minPopulation: 120_000 },
-    { key:'zoo',        label:'Zoo',        icon:'🦒', jobsBoost: 1.1, minPopulation: 140_000 },
+    { key:'healthcare', label:'Healthcare', icon:'🏥', jobsBoost: 1.3, minPopulation: 120000 },
+    { key:'zoo',        label:'Zoo',        icon:'🦒', jobsBoost: 1.1, minPopulation: 140000 },
     { key:'airport',    label:'Airport',    icon:'✈️', jobsBoost: 2.0 },
   ];
 })(window);


### PR DESCRIPTION
## Summary
- replace underscore-separated numeric literals in the runtime constants
- update the app banner checks to use plain numeric literals for broader browser support

## Testing
- python3 -m http.server 8000 *(fails: still shows Script error overlay because of existing JSX parse error)*

------
https://chatgpt.com/codex/tasks/task_e_68e1ee3c3de08322a45f321120bc7ce5