### PR TITLE
Fix error overlay compatibility for legacy browsers

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,14 @@
     </div>
   </div>
   <script>
-    window.addEventListener('error', (e)=>{
+    window.addEventListener('error', function (e) {
       const o = document.getElementById('error-overlay');
       const m = document.getElementById('err-msg');
+      const err = e && e.error;
+      const stack = err && err.stack;
+      const message = e && e.message;
       o.classList.remove('hidden');
-      m.textContent = (e?.error?.stack) || e?.message || 'Unknown error';
+      m.textContent = stack || message || 'Unknown error';
     });
   </script>
 


### PR DESCRIPTION
## Summary
- replace optional chaining in the error overlay script with legacy-safe null checks
- preserve the existing overlay behavior while avoiding syntax errors in older browsers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f0367e7c832288fff69c458f9c81