### PR TITLE
Remove outer HTML container around React root

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,9 +8,7 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-slate-50">
-  <div class="mx-auto max-w-screen-2xl px-6 md:px-10 lg:px-14">
-    <div id="root"></div>
-  </div>
+  <div id="root"></div>
 
   <!-- Error overlay so a crash isn't just a white screen -->
   <div id="error-overlay" class="hidden fixed inset-0 bg-white/95 text-rose-700 p-6">


### PR DESCRIPTION
## Summary
- replace the outer Tailwind wrapper in `index.html` with a bare root node so React controls the layout container
- confirmed the app component still provides the interior `mx-auto max-w-screen-2xl` wrapper that centers the UI

## Testing
- Manually loaded `index.html` in a browser to verify the HUD, map, and controls layout


------
https://chatgpt.com/codex/tasks/task_e_68e2901d462483229851e32ceca0ddd1