### PR TITLE
ui: fit map to viewport, simple HUD, houses-as-emoji with optional heatmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="./css/styles.css" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gradient-to-b from-sky-50 via-emerald-50/40 to-white">
+<body class="min-h-screen bg-gradient-to-b from-sky-50 via-emerald-50/40 to-white">
   <div id="root"></div>
 
   <!-- Error overlay so a crash isn't just a white screen -->


### PR DESCRIPTION
## Summary
- size the map canvas based on the available center-column height and width, add helper instructions, and include a toggle for the density heatmap
- surface a "Simple view" HUD mode alongside the existing detailed metrics to make key stats easier to scan
- render house emojis on high-population tiles while keeping the heatmap available as an optional overlay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e30626aff88322bd3571cef492c9cf