### PR TITLE
Fix map vertical alignment spacing

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -1168,7 +1168,7 @@
                     style={{ minHeight: mapAvailableHeight }}
                   >
                     <MapToast toasts={banners.mapQueue} onDismiss={banners.dismiss} />
-                    <div className="grid h-full w-full place-content-center">
+                    <div className="flex h-full w-full items-start justify-center">
                       <div className="relative" style={{ width: displaySize, height: displaySize }}>
                         <div className="absolute inset-0">
                           {Array.from({ length: paddedGrid }).map((_, y) => (


### PR DESCRIPTION
## Summary
- anchor the map rendering surface to the top of its container to eliminate the blank spacers above and below it

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e31e116ffc832282082e880c33ee6e