### PR TITLE
Fix boot error caused by map layout markup mismatch

### DIFF
--- a/js/app.jsx
+++ b/js/app.jsx
@@ -456,8 +456,8 @@
     }, [routes, enrichedRoutes, routeEstimateMap, polylineFor, routeScoreAndGrade, ROUTE_COLORS]);
 
     useEffect(() => {
-      recomputeCellSize();
-    }, [recomputeCellSize, routeSummaries.length, topBarHeight]);
+      recomputeMapSize();
+    }, [recomputeMapSize, routeSummaries.length, topBarHeight]);
 
     const activeRouteSummary = useMemo(() => routeSummaries.find(r => r.id === activeRouteId) || null, [routeSummaries, activeRouteId]);
     const gradeOrder = ['F','D','C','B','A'];
@@ -1257,7 +1257,8 @@
                     </div>
                   </div>
                 </div>
-                <div ref={mapFooterRef} className="border-t border-emerald-100/70 bg-white/70 px-4 py-3 text-xs text-slate-600">
+              </div>
+              <div ref={mapFooterRef} className="border-t border-emerald-100/70 bg-white/70 px-4 py-3 text-xs text-slate-600">
                   <div className="flex flex-wrap items-center justify-between gap-3">
                     <span className="text-[11px]">Click to add stops · Shift-click to remove · Pause to edit.</span>
                     <label className="inline-flex items-center gap-2 text-xs font-medium text-slate-600">


### PR DESCRIPTION
## Summary
- close the map content wrapper before the footer so JSX tags balance correctly
- reuse the existing recomputeMapSize helper in the route summary effect to avoid undefined reference at boot

## Testing
- Manual testing via `python3 -m http.server 8000` and visiting the app in a browser

------
https://chatgpt.com/codex/tasks/task_e_68e33a0b7ac88322966fe8af92e3f675